### PR TITLE
style: apply car wordle styles

### DIFF
--- a/src/components/optionsgrid.js
+++ b/src/components/optionsgrid.js
@@ -1,0 +1,30 @@
+export default function OptionsGrid(options, onSelect) {
+  const grid = document.createElement('div');
+  grid.className = 'options-grid';
+
+  const buttons = [];
+
+  options.forEach((option, index) => {
+    const btn = document.createElement('button');
+    btn.className = 'option-btn give-up-btn';
+    btn.style.margin = '0';
+    btn.textContent = option;
+    btn.addEventListener('click', () => onSelect(option, index));
+    grid.appendChild(btn);
+    buttons.push(btn);
+  });
+
+  const setState = (index, state) => {
+    const btn = buttons[index];
+    if (!btn) return;
+    btn.style.backgroundColor =
+      state === 'correct'
+        ? 'var(--correct)'
+        : state === 'incorrect'
+        ? 'var(--absent)'
+        : 'var(--color3)';
+    btn.style.color = 'var(--text-color)';
+  };
+
+  return { element: grid, buttons, setState };
+}

--- a/src/components/resultmodal.js
+++ b/src/components/resultmodal.js
@@ -1,0 +1,42 @@
+export default function ResultModal(message, onRestart, onClose) {
+  const overlay = document.createElement('div');
+  overlay.className = 'modal-overlay';
+
+  const modal = document.createElement('div');
+  modal.className = 'result-modal';
+  overlay.appendChild(modal);
+
+  const text = document.createElement('p');
+  text.textContent = message;
+  modal.appendChild(text);
+
+  const restartBtn = document.createElement('button');
+  restartBtn.className = 'restart-btn';
+  restartBtn.textContent = 'Reiniciar';
+  restartBtn.addEventListener('click', () => {
+    if (onRestart) onRestart();
+    close();
+  });
+  modal.appendChild(restartBtn);
+
+  const close = () => {
+    document.removeEventListener('keydown', handleKey);
+    overlay.remove();
+    if (onClose) onClose();
+  };
+
+  const handleKey = (e) => {
+    if (e.key === 'Enter') {
+      if (onRestart) onRestart();
+      close();
+    } else if (e.key === 'Escape') {
+      close();
+    }
+  };
+
+  document.addEventListener('keydown', handleKey);
+  document.body.appendChild(overlay);
+  requestAnimationFrame(() => restartBtn.focus());
+
+  return { overlay, close };
+}

--- a/src/components/topbar.js
+++ b/src/components/topbar.js
@@ -1,0 +1,26 @@
+export default function TopBar(title, actionIcon = '❓', onAction) {
+  const bar = document.createElement('div');
+  bar.className = 'top-bar';
+  bar.style.fontFamily = 'var(--font-main)';
+  bar.style.backdropFilter = 'blur(4px)';
+  bar.style.boxShadow = '0 4px 10px rgba(0, 0, 0, 0.3)';
+
+  const leftSpacer = document.createElement('div');
+  leftSpacer.className = 'top-bar-spacer';
+  bar.appendChild(leftSpacer);
+
+  const heading = document.createElement('h1');
+  heading.textContent = title;
+  bar.appendChild(heading);
+
+  const actionBtn = document.createElement('button');
+  actionBtn.className = 'give-up-btn';
+  actionBtn.style.margin = '0';
+  actionBtn.textContent = actionIcon;
+  if (onAction) {
+    actionBtn.addEventListener('click', onAction);
+  }
+  bar.appendChild(actionBtn);
+
+  return bar;
+}


### PR DESCRIPTION
## Summary
- center TopBar title and add edge-aligned action button using theme blur and shadow
- style ResultModal with reusable modal classes and keyboard shortcuts for restart and close
- update OptionsGrid buttons to match Car Wordle typography, focus and state colors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a39d74388323bac8f181d53428ae