### PR TITLE
feat: polish trivia UI with responsive layout and animations

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,12 +17,14 @@ export default function App() {
     showResult,
     score,
     restart,
+    current,
+    total,
   } = useTrivia();
 
   return (
     <GameLayout>
       <TopBar title="Car Trivia" actionIcon="🔁" onAction={restart} />
-      <QuestionCard text={question} />
+      <QuestionCard text={question} current={current} total={total} score={score} />
       <OptionsGrid
         options={options}
         onSelect={handleOption}

--- a/src/components/OptionsGrid.js
+++ b/src/components/OptionsGrid.js
@@ -2,31 +2,17 @@ import React from "react";
 
 export default function OptionsGrid({ options, onSelect, locked, selected, correctIndex }) {
   return (
-    <div className="options-grid" role="group" style={{ display: "grid", gap: "0.5rem", width: "100%" }}>
+    <div key={options.join("-")} className="options-grid fade-in" role="group">
       {options.map((opt, idx) => {
-        const baseStyle = {
-          background: "var(--color3)",
-          color: "var(--text-color)",
-          border: "2px solid var(--color3)",
-          borderRadius: "8px",
-          padding: "0.5rem 1rem",
-          cursor: locked ? "default" : "pointer",
-          margin: 0,
-        };
+        let state = "";
         if (locked) {
-          if (idx === correctIndex) {
-            baseStyle.background = "var(--correct)";
-            baseStyle.borderColor = "var(--correct)";
-          } else if (idx === selected) {
-            baseStyle.background = "var(--absent)";
-            baseStyle.borderColor = "var(--absent)";
-          }
+          if (idx === correctIndex) state = "is-correct pop";
+          else if (idx === selected) state = "is-incorrect shake";
         }
         return (
           <button
             key={idx}
-            className="option-btn give-up-btn"
-            style={baseStyle}
+            className={`option-btn btn-lg ${state}`}
             onClick={() => onSelect(idx)}
             disabled={locked}
             aria-pressed={selected === idx}

--- a/src/components/QuestionCard.js
+++ b/src/components/QuestionCard.js
@@ -1,9 +1,27 @@
 import React from "react";
 
-export default function QuestionCard({ text }) {
+export default function QuestionCard({ text, current = 0, total = 10, score = 0 }) {
+  const chips = Array.from({ length: total }).map((_, i) => (
+    <span
+      key={i}
+      className={`chip${i < current ? " is-filled" : i === current ? " is-current" : ""}`}
+    />
+  ));
+
   return (
-    <div className="question-card" aria-live="polite">
-      {text}
-    </div>
+    <section className="question-wrapper fade-in">
+      <div className="progress" aria-hidden="true">
+        {chips}
+      </div>
+      <div className="question-meta">
+        <span>
+          Pregunta {current + 1} / {total}
+        </span>
+        <span className="score">Puntos: {score}</span>
+      </div>
+      <div key={text} className="question-card card" aria-live="polite">
+        {text}
+      </div>
+    </section>
   );
 }

--- a/src/components/ResultModal.js
+++ b/src/components/ResultModal.js
@@ -3,9 +3,11 @@ import React from "react";
 export default function ResultModal({ score, onRestart }) {
   return (
     <div className="modal-overlay" role="dialog" aria-modal="true">
-      <div className="result-modal">
-        <p>Tu puntuación: {score}/10</p>
-        <button className="restart-btn" onClick={onRestart} autoFocus>
+      <div className="result-modal card fade-in">
+        <div className="result-emoji" aria-hidden="true">🏁</div>
+        <h2>Resultado</h2>
+        <p className="result-score">{score}/10</p>
+        <button className="restart-btn btn-lg" onClick={onRestart} autoFocus>
           Reiniciar
         </button>
       </div>

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -2,15 +2,12 @@ import React from "react";
 
 export default function TopBar({ title, actionIcon = "❓", onAction }) {
   return (
-    <div
-      className="top-bar"
-      style={{ backdropFilter: "blur(4px)", boxShadow: "0 4px 10px rgba(0,0,0,0.3)" }}
-    >
-      <div className="top-bar-spacer" />
+    <header className="top-bar shadow-soft" role="banner">
+      <div />
       <h1>{title}</h1>
-      <button className="give-up-btn" onClick={onAction}>
+      <button className="top-bar-action" onClick={onAction} aria-label="Reiniciar">
         {actionIcon}
       </button>
-    </div>
+    </header>
   );
 }

--- a/src/game/useTrivia.js
+++ b/src/game/useTrivia.js
@@ -82,5 +82,7 @@ export default function useTrivia() {
     score,
     restart,
     closeModal,
+    current,
+    total: questions.length,
   };
 }

--- a/src/layouts/GameLayout.js
+++ b/src/layouts/GameLayout.js
@@ -1,5 +1,9 @@
 import React from "react";
 
 export default function GameLayout({ children }) {
-  return <div className="game-container">{children}</div>;
+  return (
+    <main className="game-container">
+      <div className="container game-stack">{children}</div>
+    </main>
+  );
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -14,7 +14,7 @@
   caret-color: transparent;
 }
 body {
-  background-color: var(--color1);
+  background: linear-gradient(135deg, var(--color1), var(--color3));
   color: var(--text-color);
   font-family: var(--font-main);
   display: flex;
@@ -203,4 +203,239 @@ body {
 .give-up-btn:disabled {
   opacity: 0.5;
   cursor: default;
+}
+
+/* --- New Utility Classes and Animations --- */
+
+.container {
+  width: min(100% - 2rem, 50rem);
+  margin-inline: auto;
+}
+
+.game-stack > * + * {
+  margin-top: clamp(1rem, 4vw, 2rem);
+}
+
+.shadow-soft {
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(4px);
+}
+
+.card {
+  background: var(--color2);
+  border-radius: 16px;
+  padding: clamp(1rem, 4vw, 1.5rem);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3);
+}
+
+.btn-lg {
+  padding: clamp(0.75rem, 2vw, 1rem) 1rem;
+  font-size: clamp(1rem, 2.5vw, 1.125rem);
+  border-radius: 12px;
+  transition: background-color 180ms ease, box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.btn-lg:hover:not(:disabled) {
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+}
+
+.btn-lg:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+.btn-lg:focus-visible {
+  outline: 2px solid var(--accent, var(--text-color));
+  outline-offset: 2px;
+}
+
+.top-bar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 0.5rem 0;
+  width: 100%;
+}
+
+.top-bar h1 {
+  grid-column: 2;
+  margin: 0;
+  text-align: center;
+  font-size: clamp(1.5rem, 6vw, 2rem);
+}
+
+.top-bar-action {
+  justify-self: end;
+  background: transparent;
+  border: none;
+  color: var(--text-color);
+  font-size: 1.5rem;
+  cursor: pointer;
+  transition: transform 180ms ease;
+}
+
+.top-bar-action:hover {
+  transform: scale(1.1);
+}
+
+.top-bar-action:active {
+  transform: scale(0.95);
+}
+
+.top-bar-action:focus-visible {
+  outline: 2px solid var(--accent, var(--text-color));
+  border-radius: 50%;
+}
+
+.question-wrapper {
+  width: 100%;
+}
+
+.question-card {
+  text-align: center;
+  font-size: clamp(1rem, 3.5vw, 1.25rem);
+}
+
+.question-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.875rem;
+  margin-bottom: 0.5rem;
+}
+
+.progress {
+  display: flex;
+  justify-content: center;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.chip {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.chip.is-filled {
+  background: var(--correct);
+}
+
+.chip.is-current {
+  background: var(--present);
+}
+
+.options-grid {
+  display: grid;
+  gap: 1rem;
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .options-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.option-btn {
+  background: var(--color3);
+  color: var(--text-color);
+  border: 2px solid var(--color3);
+  border-radius: 12px;
+  padding: clamp(0.75rem, 2vw, 1rem);
+  font-size: clamp(1rem, 2.5vw, 1.125rem);
+  cursor: pointer;
+  transition: background-color 180ms ease, box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.option-btn:hover:not(:disabled) {
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+}
+
+.option-btn:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+.option-btn:focus-visible {
+  outline: 2px solid var(--accent, var(--text-color));
+  outline-offset: 2px;
+}
+
+.option-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.option-btn.is-correct {
+  background: var(--correct);
+  border-color: var(--correct);
+}
+
+.option-btn.is-incorrect {
+  background: var(--absent);
+  border-color: var(--absent);
+}
+
+.result-modal {
+  text-align: center;
+}
+
+.result-emoji {
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.result-score {
+  font-size: 1.25rem;
+  font-weight: bold;
+  margin: 0.5rem 0 1rem;
+}
+
+.fade-in {
+  animation: fade 0.4s ease;
+}
+
+.pop {
+  animation: pop 0.3s ease;
+}
+
+.shake {
+  animation: shake 0.3s ease;
+}
+
+@keyframes pop {
+  0% {
+    transform: scale(0.95);
+  }
+  70% {
+    transform: scale(1.05);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes fade {
+  from {
+    opacity: 0;
+    transform: translateY(0.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-in,
+  .pop,
+  .shake {
+    animation: none !important;
+  }
+  .btn-lg,
+  .option-btn,
+  .top-bar-action {
+    transition: none !important;
+  }
 }


### PR DESCRIPTION
## Summary
- center layout in responsive container with consistent spacing
- add progress chips, score display, and animated option states
- restyle result modal and top bar using theme utilities and transitions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68a4c23595f08323a04730e703a140a4