### PR TITLE
Improve navigation and top bar styling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import TopBar from "./components/TopBar.js";
 import QuestionCard from "./components/QuestionCard.js";
 import OptionsGrid from "./components/OptionsGrid.js";
 import ResultModal from "./components/ResultModal.js";
+import QuestionNavigation from "./components/QuestionNavigation.js";
 import useTrivia from "./game/useTrivia.js";
 
 export default function App() {
@@ -19,6 +20,9 @@ export default function App() {
     restart,
     current,
     total,
+    next,
+    prev,
+    skip,
   } = useTrivia();
 
   return (
@@ -31,6 +35,14 @@ export default function App() {
         locked={locked}
         selected={selected}
         correctIndex={correctIndex}
+      />
+      <QuestionNavigation
+        onPrev={prev}
+        onNext={next}
+        onSkip={skip}
+        disablePrev={current === 0}
+        disableNext={current >= total - 1}
+        disableSkip={locked || current >= total - 1}
       />
       {showResult && <ResultModal score={score} onRestart={restart} />}
     </GameLayout>

--- a/src/components/QuestionNavigation.js
+++ b/src/components/QuestionNavigation.js
@@ -1,0 +1,39 @@
+import React from "react";
+
+export default function QuestionNavigation({
+  onPrev,
+  onNext,
+  onSkip,
+  disablePrev,
+  disableNext,
+  disableSkip,
+}) {
+  return (
+    <div className="question-nav" role="navigation">
+      <button
+        className="btn-lg"
+        onClick={onPrev}
+        disabled={disablePrev}
+        aria-label="Ir a la pregunta anterior"
+      >
+        ⬅️ Anterior
+      </button>
+      <button
+        className="btn-lg"
+        onClick={onSkip}
+        disabled={disableSkip}
+        aria-label="Saltar pregunta"
+      >
+        ↩️ Saltar
+      </button>
+      <button
+        className="btn-lg"
+        onClick={onNext}
+        disabled={disableNext}
+        aria-label="Ir a la siguiente pregunta"
+      >
+        ➡️ Siguiente
+      </button>
+    </div>
+  );
+}

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -2,10 +2,14 @@ import React from "react";
 
 export default function TopBar({ title, actionIcon = "❓", onAction }) {
   return (
-    <header className="top-bar shadow-soft" role="banner">
-      <div />
+    <header className="top-bar" role="banner">
+      <div className="top-bar-spacer" />
       <h1>{title}</h1>
-      <button className="top-bar-action" onClick={onAction} aria-label="Reiniciar">
+      <button
+        className="top-bar-action"
+        onClick={onAction}
+        aria-label="Reiniciar"
+      >
         {actionIcon}
       </button>
     </header>

--- a/src/game/useTrivia.js
+++ b/src/game/useTrivia.js
@@ -12,6 +12,7 @@ export default function useTrivia() {
   const [locked, setLocked] = useState(false);
   const [selected, setSelected] = useState(null);
   const [showResult, setShowResult] = useState(false);
+  const [skipped, setSkipped] = useState([]);
 
   const currentQuestion = questions[current] || {};
   const correctIndex = currentQuestion.answerIndex;
@@ -25,24 +26,14 @@ export default function useTrivia() {
     setLocked(false);
     setSelected(null);
     setShowResult(false);
+    setSkipped([]);
   }, []);
 
   useEffect(() => {
     restart();
   }, [restart]);
 
-  const handleOption = useCallback(
-    (index) => {
-      if (locked) return;
-      setSelected(index);
-      setLocked(true);
-      if (index === correctIndex) setScore((s) => s + 1);
-    },
-    [locked, correctIndex]
-  );
-
   const next = useCallback(() => {
-    if (!locked) return;
     if (current + 1 >= questions.length) {
       setShowResult(true);
     } else {
@@ -50,7 +41,32 @@ export default function useTrivia() {
       setLocked(false);
       setSelected(null);
     }
-  }, [locked, current, questions.length]);
+  }, [current, questions.length]);
+
+  const prev = useCallback(() => {
+    if (current === 0) return;
+    setCurrent((c) => c - 1);
+    setLocked(false);
+    setSelected(null);
+  }, [current]);
+
+  const skip = useCallback(() => {
+    setSkipped((s) => [...s, current]);
+    next();
+  }, [current, next]);
+
+  const handleOption = useCallback(
+    (index) => {
+      if (locked) return;
+      setSelected(index);
+      setLocked(true);
+      if (index === correctIndex) {
+        setScore((s) => s + 1);
+        setTimeout(next, 800);
+      }
+    },
+    [locked, correctIndex, next]
+  );
 
   const closeModal = useCallback(() => setShowResult(false), []);
 
@@ -84,5 +100,9 @@ export default function useTrivia() {
     closeModal,
     current,
     total: questions.length,
+    next,
+    prev,
+    skip,
+    skipped,
   };
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -266,19 +266,25 @@ body {
 
 .top-bar-action {
   justify-self: end;
+  width: var(--key-size);
+  height: var(--key-size);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: transparent;
-  border: none;
+  border: 2px solid var(--text-color);
+  border-radius: 50%;
   color: var(--text-color);
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   cursor: pointer;
-  transition: transform 180ms ease;
+  transition: background-color 180ms ease, transform 180ms ease;
 }
 
-.top-bar-action:hover {
-  transform: scale(1.1);
+.top-bar-action:hover:not(:disabled) {
+  background-color: var(--color3);
 }
 
-.top-bar-action:active {
+.top-bar-action:active:not(:disabled) {
   transform: scale(0.95);
 }
 
@@ -329,6 +335,14 @@ body {
   display: grid;
   gap: 1rem;
   width: 100%;
+}
+
+.question-nav {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
 }
 
 @media (min-width: 640px) {


### PR DESCRIPTION
## Summary
- Polish top bar with Car Wordle-style action button and centered title
- Add question navigation controls with prev/next/skip
- Extend trivia hook for navigation and auto-advance on correct answers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4c6c946b48323b87849501692562a