### PR TITLE
feat: improve trivia navigation and styling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,7 @@ export default function App() {
   const {
     question,
     options,
-    handleOption,
+    pickOption,
     locked,
     selected,
     correctIndex,
@@ -23,26 +23,30 @@ export default function App() {
     next,
     prev,
     skip,
+    status,
+    canPrev,
+    canNext,
+    canSkip,
   } = useTrivia();
 
   return (
     <GameLayout>
       <TopBar title="Car Trivia" actionIcon="🔁" onAction={restart} />
-      <QuestionCard text={question} current={current} total={total} score={score} />
+      <QuestionCard text={question} current={current} total={total} status={status} />
       <OptionsGrid
         options={options}
-        onSelect={handleOption}
+        onSelect={pickOption}
         locked={locked}
         selected={selected}
         correctIndex={correctIndex}
       />
       <QuestionNavigation
         onPrev={prev}
-        onNext={next}
         onSkip={skip}
-        disablePrev={current === 0}
-        disableNext={current >= total - 1}
-        disableSkip={locked || current >= total - 1}
+        onNext={next}
+        canPrev={canPrev}
+        canSkip={canSkip}
+        canNext={canNext}
       />
       {showResult && <ResultModal score={score} onRestart={restart} />}
     </GameLayout>

--- a/src/components/OptionsGrid.js
+++ b/src/components/OptionsGrid.js
@@ -12,7 +12,7 @@ export default function OptionsGrid({ options, onSelect, locked, selected, corre
         return (
           <button
             key={idx}
-            className={`option-btn btn-lg ${state}`}
+            className={`option-btn ${state}`}
             onClick={() => onSelect(idx)}
             disabled={locked}
             aria-pressed={selected === idx}

--- a/src/components/QuestionCard.js
+++ b/src/components/QuestionCard.js
@@ -1,23 +1,26 @@
 import React from "react";
 
-export default function QuestionCard({ text, current = 0, total = 10, score = 0 }) {
-  const chips = Array.from({ length: total }).map((_, i) => (
-    <span
-      key={i}
-      className={`chip${i < current ? " is-filled" : i === current ? " is-current" : ""}`}
-    />
-  ));
+export default function QuestionCard({ text, current = 0, total = 10, status = [] }) {
+  const chips = Array.from({ length: total }).map((_, i) => {
+    const st = status[i] || "pending";
+    const cls =
+      st === "correct"
+        ? "is-correct"
+        : st === "incorrect"
+        ? "is-incorrect"
+        : "is-skipped";
+    return <span key={i} className={`chip ${cls}`} />;
+  });
 
   return (
     <section className="question-wrapper fade-in">
-      <div className="progress" aria-hidden="true">
-        {chips}
-      </div>
       <div className="question-meta">
         <span>
           Pregunta {current + 1} / {total}
         </span>
-        <span className="score">Puntos: {score}</span>
+        <div className="progress" aria-hidden="true">
+          {chips}
+        </div>
       </div>
       <div key={text} className="question-card card" aria-live="polite">
         {text}

--- a/src/components/QuestionNavigation.js
+++ b/src/components/QuestionNavigation.js
@@ -2,37 +2,37 @@ import React from "react";
 
 export default function QuestionNavigation({
   onPrev,
-  onNext,
   onSkip,
-  disablePrev,
-  disableNext,
-  disableSkip,
+  onNext,
+  canPrev,
+  canSkip,
+  canNext,
 }) {
   return (
     <div className="question-nav" role="navigation">
       <button
-        className="btn-lg"
+        className="nav-btn"
         onClick={onPrev}
-        disabled={disablePrev}
+        disabled={!canPrev}
         aria-label="Ir a la pregunta anterior"
       >
-        ⬅️ Anterior
+        Anterior
       </button>
       <button
-        className="btn-lg"
+        className="nav-btn"
         onClick={onSkip}
-        disabled={disableSkip}
+        disabled={!canSkip}
         aria-label="Saltar pregunta"
       >
-        ↩️ Saltar
+        Saltar
       </button>
       <button
-        className="btn-lg"
+        className="nav-btn"
         onClick={onNext}
-        disabled={disableNext}
+        disabled={!canNext}
         aria-label="Ir a la siguiente pregunta"
       >
-        ➡️ Siguiente
+        Siguiente
       </button>
     </div>
   );

--- a/src/components/ResultModal.js
+++ b/src/components/ResultModal.js
@@ -7,7 +7,7 @@ export default function ResultModal({ score, onRestart }) {
         <div className="result-emoji" aria-hidden="true">🏁</div>
         <h2>Resultado</h2>
         <p className="result-score">{score}/10</p>
-        <button className="restart-btn btn-lg" onClick={onRestart} autoFocus>
+        <button className="restart-btn nav-btn" onClick={onRestart} autoFocus>
           Reiniciar
         </button>
       </div>

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -3,7 +3,7 @@ import React from "react";
 export default function TopBar({ title, actionIcon = "❓", onAction }) {
   return (
     <header className="top-bar" role="banner">
-      <div className="top-bar-spacer" />
+      <div className="top-bar-spacer" aria-hidden="true" />
       <h1>{title}</h1>
       <button
         className="top-bar-action"

--- a/src/theme.css
+++ b/src/theme.css
@@ -6,6 +6,7 @@
   --correct: #538d4e;
   --present: #b59f3b;
   --absent: #3a3a3c;
+  --error: hsl(0 72% 55%);
   --tile-size: clamp(3.2rem, 9vw, 4.2rem);
   --key-size: clamp(2.5rem, 8vw, 3.5rem);
   --font-main: 'Roboto', sans-serif;
@@ -33,20 +34,44 @@ body {
 .top-bar {
   width: 100%;
   max-width: 600px;
-  display: flex;
+  display: grid;
+  grid-template-columns: var(--key-size) 1fr var(--key-size);
   align-items: center;
-  gap: 0.5rem;
   padding: 0 0.5rem;
 }
 
 .top-bar h1 {
-  flex: 1;
   margin: 0;
   text-align: center;
 }
 
 .top-bar-spacer {
   width: var(--key-size);
+  height: var(--key-size);
+}
+
+.top-bar-action {
+  width: var(--key-size);
+  height: var(--key-size);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 2px solid var(--text-color);
+  border-radius: 50%;
+  color: var(--text-color);
+  cursor: pointer;
+  transition: background-color 180ms ease, transform 180ms ease;
+}
+
+.top-bar-action:hover,
+.top-bar-action:focus-visible {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.top-bar-action:focus-visible {
+  outline: 2px solid var(--accent, var(--text-color));
+  outline-offset: 2px;
 }
 .message {
   min-height: 1.5rem;
@@ -249,50 +274,6 @@ body {
   outline-offset: 2px;
 }
 
-.top-bar {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  padding: 0.5rem 0;
-  width: 100%;
-}
-
-.top-bar h1 {
-  grid-column: 2;
-  margin: 0;
-  text-align: center;
-  font-size: clamp(1.5rem, 6vw, 2rem);
-}
-
-.top-bar-action {
-  justify-self: end;
-  width: var(--key-size);
-  height: var(--key-size);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  border: 2px solid var(--text-color);
-  border-radius: 50%;
-  color: var(--text-color);
-  font-size: 1.25rem;
-  cursor: pointer;
-  transition: background-color 180ms ease, transform 180ms ease;
-}
-
-.top-bar-action:hover:not(:disabled) {
-  background-color: var(--color3);
-}
-
-.top-bar-action:active:not(:disabled) {
-  transform: scale(0.95);
-}
-
-.top-bar-action:focus-visible {
-  outline: 2px solid var(--accent, var(--text-color));
-  border-radius: 50%;
-}
-
 .question-wrapper {
   width: 100%;
 }
@@ -300,6 +281,10 @@ body {
 .question-card {
   text-align: center;
   font-size: clamp(1rem, 3.5vw, 1.25rem);
+  min-height: 4.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .question-meta {
@@ -307,27 +292,30 @@ body {
   justify-content: space-between;
   font-size: 0.875rem;
   margin-bottom: 0.5rem;
+  align-items: center;
 }
 
 .progress {
   display: flex;
-  justify-content: center;
   gap: 0.25rem;
-  margin-bottom: 0.5rem;
 }
 
 .chip {
   width: 0.6rem;
   height: 0.6rem;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.3);
+  background: var(--present);
 }
 
-.chip.is-filled {
+.chip.is-correct {
   background: var(--correct);
 }
 
-.chip.is-current {
+.chip.is-incorrect {
+  background: var(--error);
+}
+
+.chip.is-skipped {
   background: var(--present);
 }
 
@@ -335,6 +323,7 @@ body {
   display: grid;
   gap: 1rem;
   width: 100%;
+  grid-template-columns: 1fr;
 }
 
 .question-nav {
@@ -352,18 +341,20 @@ body {
 }
 
 .option-btn {
-  background: var(--color3);
+  background: transparent;
   color: var(--text-color);
   border: 2px solid var(--color3);
   border-radius: 12px;
   padding: clamp(0.75rem, 2vw, 1rem);
   font-size: clamp(1rem, 2.5vw, 1.125rem);
   cursor: pointer;
+  min-height: 3rem;
   transition: background-color 180ms ease, box-shadow 180ms ease,
     transform 180ms ease;
 }
 
 .option-btn:hover:not(:disabled) {
+  background: var(--color2);
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
 }
 
@@ -387,8 +378,44 @@ body {
 }
 
 .option-btn.is-incorrect {
-  background: var(--absent);
-  border-color: var(--absent);
+  background: var(--error);
+  border-color: var(--error);
+}
+
+.option-btn.is-skipped {
+  background: var(--present);
+  border-color: var(--present);
+}
+
+.nav-btn {
+  background: transparent;
+  color: var(--text-color);
+  border: 2px solid var(--color3);
+  border-radius: 12px;
+  padding: clamp(0.75rem, 2vw, 1rem) 1.25rem;
+  min-height: 3rem;
+  cursor: pointer;
+  transition: background-color 180ms ease, box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.nav-btn:hover:not(:disabled) {
+  background: var(--color2);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+}
+
+.nav-btn:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+.nav-btn:focus-visible {
+  outline: 2px solid var(--accent, var(--text-color));
+  outline-offset: 2px;
+}
+
+.nav-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
 }
 
 .result-modal {
@@ -449,7 +476,8 @@ body {
   }
   .btn-lg,
   .option-btn,
-  .top-bar-action {
+  .top-bar-action,
+  .nav-btn {
     transition: none !important;
   }
 }


### PR DESCRIPTION
## Summary
- refactor trivia hook to track question status and support skip/prev/next navigation
- add outline-styled buttons and colored progress indicators
- redesign top bar and layout for consistent spacing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4ed7efe0c832396395070b4f68b58