### PR TITLE
Refine Car Trivia UI and navigation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,40 +5,46 @@ import QuestionCard from "./components/QuestionCard.js";
 import OptionsGrid from "./components/OptionsGrid.js";
 import ResultModal from "./components/ResultModal.js";
 import QuestionNavigation from "./components/QuestionNavigation.js";
-import useTrivia from "./game/useTrivia.js";
+import { useTrivia } from "./game/useTrivia.js";
 
 export default function App() {
   const {
-    question,
-    options,
-    pickOption,
-    locked,
-    selected,
-    correctIndex,
-    showResult,
-    score,
-    restart,
     current,
+    questionIndex,
     total,
+    optionsState,
+    pickOption,
     next,
     prev,
     skip,
-    status,
+    finished,
+    score,
+    restart,
+    handleKeyDown,
     canPrev,
     canNext,
     canSkip,
+    status,
   } = useTrivia();
+
+  React.useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
 
   return (
     <GameLayout>
-      <TopBar title="Car Trivia" actionIcon="🔁" onAction={restart} />
-      <QuestionCard text={question} current={current} total={total} status={status} />
+      <TopBar title="Car Trivia" actionEmoji="🔁" onAction={restart} />
+      <QuestionCard
+        text={current.question}
+        current={questionIndex}
+        total={total}
+        status={status}
+      />
       <OptionsGrid
-        options={options}
-        onSelect={pickOption}
-        locked={locked}
-        selected={selected}
-        correctIndex={correctIndex}
+        options={current.options}
+        onPick={pickOption}
+        state={optionsState}
       />
       <QuestionNavigation
         onPrev={prev}
@@ -48,7 +54,7 @@ export default function App() {
         canSkip={canSkip}
         canNext={canNext}
       />
-      {showResult && <ResultModal score={score} onRestart={restart} />}
+      {finished && <ResultModal score={score} onRestart={restart} />}
     </GameLayout>
   );
 }

--- a/src/components/OptionsGrid.js
+++ b/src/components/OptionsGrid.js
@@ -1,21 +1,21 @@
 import React from "react";
 
-export default function OptionsGrid({ options, onSelect, locked, selected, correctIndex }) {
+export default function OptionsGrid({ options, onPick, state }) {
   return (
-    <div key={options.join("-")} className="options-grid fade-in" role="group">
-      {options.map((opt, idx) => {
-        let state = "";
-        if (locked) {
-          if (idx === correctIndex) state = "is-correct pop";
-          else if (idx === selected) state = "is-incorrect shake";
+    <div key={options.join("-")} className="options-grid" role="group">
+      {options.map((opt, i) => {
+        let cls = "option-btn";
+        if (state.locked) {
+          if (i === state.correctIndex) cls += " is-correct";
+          else if (i === state.chosenIndex) cls += " is-incorrect";
         }
         return (
           <button
-            key={idx}
-            className={`option-btn ${state}`}
-            onClick={() => onSelect(idx)}
-            disabled={locked}
-            aria-pressed={selected === idx}
+            key={i}
+            className={cls}
+            disabled={state.locked}
+            onClick={() => onPick(i)}
+            aria-pressed={state.chosenIndex === i}
           >
             {opt}
           </button>

--- a/src/components/QuestionCard.js
+++ b/src/components/QuestionCard.js
@@ -1,15 +1,14 @@
 import React from "react";
 
 export default function QuestionCard({ text, current = 0, total = 10, status = [] }) {
-  const chips = Array.from({ length: total }).map((_, i) => {
-    const st = status[i] || "pending";
-    const cls =
-      st === "correct"
-        ? "is-correct"
-        : st === "incorrect"
-        ? "is-incorrect"
-        : "is-skipped";
-    return <span key={i} className={`chip ${cls}`} />;
+  const dots = Array.from({ length: total }).map((_, i) => {
+    const st = status[i];
+    let cls = "progress-dot";
+    if (i === current) cls += " is-current";
+    if (st === "correct") cls += " is-correct";
+    else if (st === "incorrect") cls += " is-incorrect";
+    else if (st === "skipped") cls += " is-skipped";
+    return <span key={i} className={cls} />;
   });
 
   return (
@@ -19,10 +18,10 @@ export default function QuestionCard({ text, current = 0, total = 10, status = [
           Pregunta {current + 1} / {total}
         </span>
         <div className="progress" aria-hidden="true">
-          {chips}
+          {dots}
         </div>
       </div>
-      <div key={text} className="question-card card" aria-live="polite">
+      <div key={text} className="question-card" aria-live="polite">
         {text}
       </div>
     </section>

--- a/src/components/QuestionNavigation.js
+++ b/src/components/QuestionNavigation.js
@@ -1,39 +1,14 @@
 import React from "react";
 
 export default function QuestionNavigation({
-  onPrev,
-  onSkip,
-  onNext,
-  canPrev,
-  canSkip,
-  canNext,
+  onPrev, onSkip, onNext,
+  canPrev, canSkip, canNext
 }) {
   return (
-    <div className="question-nav" role="navigation">
-      <button
-        className="nav-btn"
-        onClick={onPrev}
-        disabled={!canPrev}
-        aria-label="Ir a la pregunta anterior"
-      >
-        Anterior
-      </button>
-      <button
-        className="nav-btn"
-        onClick={onSkip}
-        disabled={!canSkip}
-        aria-label="Saltar pregunta"
-      >
-        Saltar
-      </button>
-      <button
-        className="nav-btn"
-        onClick={onNext}
-        disabled={!canNext}
-        aria-label="Ir a la siguiente pregunta"
-      >
-        Siguiente
-      </button>
+    <div className="nav-row" role="group" aria-label="Navegación de preguntas">
+      <button className="nav-btn" onClick={onPrev} disabled={!canPrev} aria-label="Anterior">⬅️ Anterior</button>
+      <button className="nav-btn" onClick={onSkip} disabled={!canSkip} aria-label="Saltar">⏭️ Saltar</button>
+      <button className="nav-btn" onClick={onNext} disabled={!canNext} aria-label="Siguiente">➡️ Siguiente</button>
     </div>
   );
 }

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -1,16 +1,12 @@
 import React from "react";
 
-export default function TopBar({ title, actionIcon = "❓", onAction }) {
+export default function TopBar({ title, actionEmoji = "❓", onAction }) {
   return (
     <header className="top-bar" role="banner">
       <div className="top-bar-spacer" aria-hidden="true" />
       <h1>{title}</h1>
-      <button
-        className="top-bar-action"
-        onClick={onAction}
-        aria-label="Reiniciar"
-      >
-        {actionIcon}
+      <button className="icon-btn" onClick={onAction} aria-label="Reiniciar">
+        {actionEmoji}
       </button>
     </header>
   );

--- a/src/theme.css
+++ b/src/theme.css
@@ -411,3 +411,109 @@ button:disabled {
     transition: none !important;
   }
 }
+
+/* === Car Trivia – UI refinements === */
+
+/* Contenedor vertical consistente */
+.game-container {
+  display: grid;
+  grid-template-rows: auto auto 1fr auto; /* meta/progreso | pregunta | opciones | navegación */
+  row-gap: clamp(12px, 2.2vw, 20px);
+  max-width: 720px;
+  margin-inline: auto;
+  padding-inline: clamp(12px, 2.2vw, 24px);
+}
+
+/* Pregunta con altura mínima estable para evitar saltos */
+.question-card {
+  min-height: clamp(96px, 14vh, 140px); /* 2–3 líneas */
+  display: grid;
+  align-content: center;
+  padding: clamp(12px, 2vw, 20px);
+  border-radius: var(--radius, 12px);
+  box-shadow: var(--shadow, 0 10px 24px rgba(0,0,0,.15));
+}
+
+/* Grilla de opciones uniforme */
+.options-grid {
+  display: grid;
+  gap: clamp(10px, 2vw, 16px);
+  grid-template-columns: 1fr; /* mobile */
+}
+@media (min-width: 640px) {
+  .options-grid { grid-template-columns: 1fr 1fr; }
+}
+
+/* Botones de opción con altura mínima uniforme */
+.option-btn {
+  min-height: 56px;
+  border-radius: var(--radius, 12px);
+  border: 1px solid var(--accent, rgba(255,255,255,.2));
+  transition: background-color .18s, color .18s, border-color .18s, transform .18s, box-shadow .18s;
+}
+
+/* Al bloquear la pregunta, desactiva interacción, PERO no apagues el color de estado */
+.option-btn:disabled { opacity: .6; cursor: default; }
+.option-btn.is-correct,
+.option-btn.is-incorrect {
+  opacity: 1;                 /* <- quita opacidad lavada */
+  color: var(--text-color, #fff);
+}
+.option-btn.is-correct {
+  background: var(--correct);
+  border-color: var(--correct);
+  animation: pop .18s ease-out;
+}
+.option-btn.is-incorrect {
+  background: var(--error, hsl(0 72% 55%));
+  border-color: var(--error, hsl(0 72% 55%));
+  animation: shake .24s linear;
+}
+
+/* Barra de progreso: 3 estados */
+.progress-dot { opacity: .5; }
+.progress-dot.is-current { opacity: 1; }
+.progress-dot.is-correct { background: var(--correct) !important; opacity: 1; }
+.progress-dot.is-incorrect { background: var(--error, hsl(0 72% 55%)) !important; opacity: 1; }
+.progress-dot.is-skipped { background: var(--present) !important; opacity: 1; }
+
+/* Navegación: 3 botones uniformes */
+.nav-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: clamp(10px, 2vw, 16px);
+  justify-items: center;
+}
+.nav-btn {
+  min-height: 44px;
+  padding: 10px 16px;
+  border-radius: var(--radius, 12px);
+  background: transparent;
+  border: 1px solid var(--accent, rgba(255,255,255,.25));
+  color: var(--text-color, #fff);
+  transition: background-color .18s, border-color .18s, box-shadow .18s, transform .18s;
+}
+.nav-btn:hover:not(:disabled) { transform: translateY(-1px); }
+.nav-btn:disabled { opacity: .5; }
+
+/* Emoji del TopBar: borde/outline, sin caja de fondo */
+.icon-btn {
+  background: transparent;
+  border: 1px solid var(--accent, rgba(255,255,255,.25));
+  border-radius: 999px;
+  padding: 8px;
+  box-shadow: none;
+}
+
+/* Animaciones sutiles */
+@keyframes pop { 0%{transform: scale(.98)} 100%{transform: scale(1)} }
+@keyframes shake {
+  0%{ transform: translateX(0) } 25%{ transform: translateX(-2px) }
+  50%{ transform: translateX(2px) } 75%{ transform: translateX(-2px) } 100%{ transform: translateX(0) }
+}
+
+/* Respeta reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .option-btn, .nav-btn { transition: none; }
+  .option-btn.is-correct, .option-btn.is-incorrect { animation: none; }
+}


### PR DESCRIPTION
## Summary
- Improve layout and styling for consistent grid, question card sizing, option button states, progress dots, navigation buttons, and top-bar icon styles
- Implement responsive option selection classes and new navigation component with prev/skip/next controls
- Replace trivia game hook with status tracking, navigation handlers, and auto-advance on correct answers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4f413565883239dc2f796d41f14e0